### PR TITLE
fix(links): correct URLs for New Comers, Level 1, Level 2, and Senior training

### DIFF
--- a/docs/training/plan/Level1_training.md
+++ b/docs/training/plan/Level1_training.md
@@ -16,7 +16,7 @@
   </div>
 
   <div class="training-path">
-    <a href="../Newcommer_training.md" class="path-step">
+    <a href="../Newcommer_training" class="path-step">
       <div class="path-step-icon">0</div>
       <div class="path-step-title">Newcomer</div>
     </a>
@@ -26,12 +26,12 @@
       <div class="path-step-title">Level 1</div>
     </div>
     <div class="path-connector"></div>
-    <a href="../Level2_training.md" class="path-step">
+    <a href="../Level2_training" class="path-step">
       <div class="path-step-icon">2</div>
       <div class="path-step-title">Level 2</div>
     </a>
     <div class="path-connector"></div>
-    <a href="../Senior_training.md" class="path-step">
+    <a href="../Senior_training" class="path-step">
       <div class="path-step-icon">3</div>
       <div class="path-step-title">Senior</div>
     </a>

--- a/docs/training/plan/Level2_training.md
+++ b/docs/training/plan/Level2_training.md
@@ -6,12 +6,12 @@
 </div>
 
 <div class="training-path">
-  <a href="../Newcommer_training.md" class="path-step">
+  <a href="../Newcommer_training" class="path-step">
     <div class="path-step-icon">0</div>
     <div class="path-step-title">Newcomer</div>
   </a>
   <div class="path-connector"></div>
-  <a href="../Level1_training.md" class="path-step">
+  <a href="../Level1_training" class="path-step">
     <div class="path-step-icon">1</div>
     <div class="path-step-title">Level 1</div>
   </a>
@@ -21,7 +21,7 @@
     <div class="path-step-title">Level 2</div>
   </div>
   <div class="path-connector"></div>
-  <a href="../Senior_training.md" class="path-step">
+  <a href="../Senior_training" class="path-step">
     <div class="path-step-icon">3</div>
     <div class="path-step-title">Senior</div>
   </a>

--- a/docs/training/plan/Newcommer_training.md
+++ b/docs/training/plan/Newcommer_training.md
@@ -11,17 +11,17 @@
     <div class="path-step-title">Newcomer</div>
   </div>
   <div class="path-connector"></div>
-  <a href="../Level1_training.md" class="path-step">
+  <a href="../Level1_training" class="path-step">
     <div class="path-step-icon">1</div>
     <div class="path-step-title">Level 1</div>
   </a>
   <div class="path-connector"></div>
-  <a href="../Level2_training.md" class="path-step">
+  <a href="../Level2_training" class="path-step">
     <div class="path-step-icon">2</div>
     <div class="path-step-title">Level 2</div>
   </a>
   <div class="path-connector"></div>
-  <a href="../Senior_training.md" class="path-step">
+  <a href="../Senior_training" class="path-step">
     <div class="path-step-icon">3</div>
     <div class="path-step-title">Senior</div>
   </a>


### PR DESCRIPTION
Fix URLs for New Comers, Level 1, Level 2, and Senior training in `training/plan` route