### PR TITLE
fix : removed 'All community Sessions' from Resources list

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,7 +95,6 @@ nav:
       - Overview: resources/index.md
       - Sessions Archive: resources/sessions/index.md
       - FAQ: resources/FAQ.md
-      - All Community Sessions: resources/all-community-sessions.md
   - News:
       - Overview: news/index.md
       - 2025 Events: news/2025_events.md


### PR DESCRIPTION
Removed 'All community Sessions' from the Resources list as it was moved to 'Sessions Archive'